### PR TITLE
Add fullscreen mode (query & toggle)

### DIFF
--- a/pugl/pugl.h
+++ b/pugl/pugl.h
@@ -1,5 +1,6 @@
 /*
   Copyright 2012-2016 David Robillard <http://drobilla.net>
+  Copyright 2019 Thomas Brand <tom@trellis.ch>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -645,6 +646,21 @@ puglGetProcAddress(const char* name);
 */
 PUGL_API void
 puglPostRedisplay(PuglView* view);
+
+/**
+   Toggle fullscreen mode on/off
+*/
+PUGL_API void
+puglToggleFullScreen(PuglView* view);
+
+/**
+   Return the current fullscreen status
+   0: Not in fullscreen mode
+   1: Fullscreen active
+   2: Error (unknown fullscreen status)
+*/
+PUGL_API int
+puglIsFullScreen(PuglView* view);
 
 /**
    Destroy a GL window.

--- a/pugl/pugl_osx.m
+++ b/pugl/pugl_osx.m
@@ -1,6 +1,7 @@
 /*
   Copyright 2012-2017 David Robillard <http://drobilla.net>
   Copyright 2017 Hanspeter Portner <dev@open-music-kontrollers.ch>
+  Copyright 2019 Thomas Brand <tom@trellis.ch>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -642,6 +643,20 @@ puglHideWindow(PuglView* view)
 	view->visible = false;
 }
 
+int
+puglIsFullScreen(PuglView* view)
+{
+	return (([view->impl->window styleMask] & NSFullScreenWindowMask)
+		== NSFullScreenWindowMask);
+}
+
+void
+puglToggleFullScreen(PuglView* view)
+{
+	if (!view->hints.resizable) {return;}
+	[view->impl->window toggleFullScreen:nil];
+}
+
 void
 puglDestroy(PuglView* view)
 {
@@ -686,17 +701,13 @@ puglWaitForEvent(PuglView* view)
 PuglStatus
 puglProcessEvents(PuglView* view)
 {
-	while (true) {
-		// Get the next event, or use the cached one from puglWaitForEvent
-		if (!view->impl->nextEvent) {
-			view->impl->nextEvent = [view->impl->window
-			                            nextEventMatchingMask: NSAnyEventMask];
-		}
+	// Get the next event, or use the cached one from puglWaitForEvent
+	if (!view->impl->nextEvent) {
+		view->impl->nextEvent = [view->impl->window
+		                            nextEventMatchingMask: NSAnyEventMask];
+	}
 
-		if (!view->impl->nextEvent) {
-			break;  // No events to process, done
-		}
-
+	if (view->impl->nextEvent != NULL) {
 		// Dispatch event
 		[view->impl->app sendEvent: view->impl->nextEvent];
 		view->impl->nextEvent = NULL;


### PR DESCRIPTION
These functions have been tested as good as possible on all supported platforms.

On Windows: leaving fullscreen will not respect previous window
position and size. It will be at 0,0 with defined min_width, min_height.

(commit includes "Prevent infinite loop in puglProcessEvents() (OSX)")