### PR TITLE
Some fixes

### DIFF
--- a/pugl/pugl.h
+++ b/pugl/pugl.h
@@ -116,9 +116,7 @@ typedef enum {
    Convenience symbols for ASCII control characters.
 */
 typedef enum {
-	PUGL_CHAR_BACKSPACE = 0x08,
 	PUGL_CHAR_ESCAPE    = 0x1B,
-	PUGL_CHAR_DELETE    = 0x7F
 } PuglChar;
 
 /**
@@ -152,6 +150,8 @@ typedef enum {
 	PUGL_KEY_F10,
 	PUGL_KEY_F11,
 	PUGL_KEY_F12,
+        PUGL_KEY_BACKSPACE,
+        PUGL_KEY_DELETE,
 	PUGL_KEY_LEFT,
 	PUGL_KEY_UP,
 	PUGL_KEY_RIGHT,

--- a/pugl/pugl.h
+++ b/pugl/pugl.h
@@ -218,7 +218,7 @@ typedef struct {
 	PuglEventType type;        /**< PUGL_BUTTON_PRESS or PUGL_BUTTON_RELEASE. */
 	PuglView*     view;        /**< View that received this event. */
 	uint32_t      flags;       /**< Bitwise OR of PuglEventFlag values. */
-	uint32_t      time;        /**< Time in milliseconds. */
+	double        time;        /**< Time in seconds. */
 	double        x;           /**< View-relative X coordinate. */
 	double        y;           /**< View-relative Y coordinate. */
 	double        x_root;      /**< Root-relative X coordinate. */
@@ -288,7 +288,7 @@ typedef struct {
 	PuglEventType type;        /**< PUGL_KEY_PRESS or PUGL_KEY_RELEASE. */
 	PuglView*     view;        /**< View that received this event. */
 	uint32_t      flags;       /**< Bitwise OR of PuglEventFlag values. */
-	uint32_t      time;        /**< Time in milliseconds. */
+	double        time;        /**< Time in seconds. */
 	double        x;           /**< View-relative X coordinate. */
 	double        y;           /**< View-relative Y coordinate. */
 	double        x_root;      /**< Root-relative X coordinate. */
@@ -308,7 +308,7 @@ typedef struct {
 	PuglEventType    type;     /**< PUGL_ENTER_NOTIFY or PUGL_LEAVE_NOTIFY. */
 	PuglView*        view;     /**< View that received this event. */
 	uint32_t         flags;    /**< Bitwise OR of PuglEventFlag values. */
-	uint32_t         time;     /**< Time in milliseconds. */
+	double           time;     /**< Time in seconds. */
 	double           x;        /**< View-relative X coordinate. */
 	double           y;        /**< View-relative Y coordinate. */
 	double           x_root;   /**< Root-relative X coordinate. */
@@ -324,7 +324,7 @@ typedef struct {
 	PuglEventType type;        /**< PUGL_MOTION_NOTIFY. */
 	PuglView*     view;        /**< View that received this event. */
 	uint32_t      flags;       /**< Bitwise OR of PuglEventFlag values. */
-	uint32_t      time;        /**< Time in milliseconds. */
+	double        time;        /**< Time in seconds. */
 	double        x;           /**< View-relative X coordinate. */
 	double        y;           /**< View-relative Y coordinate. */
 	double        x_root;      /**< Root-relative X coordinate. */
@@ -347,7 +347,7 @@ typedef struct {
 	PuglEventType type;        /**< PUGL_SCROLL. */
 	PuglView*     view;        /**< View that received this event. */
 	uint32_t      flags;       /**< Bitwise OR of PuglEventFlag values. */
-	uint32_t      time;        /**< Time in milliseconds. */
+	double        time;        /**< Time in seconds. */
 	double        x;           /**< View-relative X coordinate. */
 	double        y;           /**< View-relative Y coordinate. */
 	double        x_root;      /**< Root-relative X coordinate. */

--- a/pugl/pugl_osx.m
+++ b/pugl/pugl_osx.m
@@ -695,7 +695,11 @@ puglProcessEvents(PuglView* view)
 		// Get the next event, or use the cached one from puglWaitForEvent
 		if (!view->impl->nextEvent) {
 			view->impl->nextEvent = [view->impl->window
-			                            nextEventMatchingMask: NSAnyEventMask];
+			                            nextEventMatchingMask: NSAnyEventMask
+                                                    untilDate:nil
+                                                    inMode:NSDefaultRunLoopMode
+                                                    dequeue:YES];
+
 		}
 
 		if (!view->impl->nextEvent) {

--- a/pugl/pugl_osx.m
+++ b/pugl/pugl_osx.m
@@ -595,8 +595,8 @@ puglCreateWindow(PuglView* view, const char* title)
 		[impl->glview setAutoresizingMask:NSViewNotSizable];
 	}
 
-	if (view->transient_parent) {
-		NSView* pview = (NSView*)view->transient_parent;
+	if (view->parent) {
+		NSView* pview = (NSView*)view->parent;
 		[pview addSubview:impl->glview];
 		[impl->glview setHidden:NO];
 	} else {

--- a/pugl/pugl_osx.m
+++ b/pugl/pugl_osx.m
@@ -439,7 +439,8 @@ keySymToSpecial(PuglView* view, NSEvent* ev)
 	const NSPoint      rloc  = [NSEvent mouseLocation];
 	const NSString*    chars = [event characters];
 	const char*        str   = [chars UTF8String];
-	const uint32_t     code  = puglDecodeUTF8((const uint8_t*)str);
+        const PuglKey      special = keySymToSpecial(puglview, event);
+        const uint32_t     code  = special ? 0 : puglDecodeUTF8((const uint8_t*)str);
 	PuglEventKey       ev    =  {
 		PUGL_KEY_PRESS,
 		puglview,
@@ -466,6 +467,8 @@ keySymToSpecial(PuglView* view, NSEvent* ev)
 	const NSPoint      rloc  = [NSEvent mouseLocation];
 	const NSString*    chars = [event characters];
 	const char*        str   = [chars UTF8String];
+        const PuglKey      special = keySymToSpecial(puglview, event);
+        const uint32_t     code  = special ? 0 : puglDecodeUTF8((const uint8_t*)str);
 	const PuglEventKey ev    =  {
 		PUGL_KEY_RELEASE,
 		puglview,
@@ -477,7 +480,7 @@ keySymToSpecial(PuglView* view, NSEvent* ev)
 		[[NSScreen mainScreen] frame].size.height - rloc.y,
 		getModifiers(puglview, event),
 		[event keyCode],
-		puglDecodeUTF8((const uint8_t*)str),
+		(code != 0xFFFD) ? code : 0,
 		keySymToSpecial(puglview, event),
 		{ 0, 0, 0, 0, 0, 0, 0, 0 },
 		false,

--- a/pugl/pugl_osx.m
+++ b/pugl/pugl_osx.m
@@ -264,6 +264,8 @@ keySymToSpecial(PuglView* view, NSEvent* ev)
 		case NSF10FunctionKey:        return PUGL_KEY_F10;
 		case NSF11FunctionKey:        return PUGL_KEY_F11;
 		case NSF12FunctionKey:        return PUGL_KEY_F12;
+                case NSDeleteCharacter:       return PUGL_KEY_BACKSPACE;
+                case NSDeleteFunctionKey:     return PUGL_KEY_DELETE;
 		case NSLeftArrowFunctionKey:  return PUGL_KEY_LEFT;
 		case NSUpArrowFunctionKey:    return PUGL_KEY_UP;
 		case NSRightArrowFunctionKey: return PUGL_KEY_RIGHT;

--- a/pugl/pugl_win.cpp
+++ b/pugl/pugl_win.cpp
@@ -250,6 +250,8 @@ keySymToSpecial(int sym)
 	case VK_F10:     return PUGL_KEY_F10;
 	case VK_F11:     return PUGL_KEY_F11;
 	case VK_F12:     return PUGL_KEY_F12;
+        case VK_BACK:    return PUGL_KEY_BACKSPACE;
+        case VK_DELETE:  return PUGL_KEY_DELETE;
 	case VK_LEFT:    return PUGL_KEY_LEFT;
 	case VK_UP:      return PUGL_KEY_UP;
 	case VK_RIGHT:   return PUGL_KEY_RIGHT;

--- a/pugl/pugl_win.cpp
+++ b/pugl/pugl_win.cpp
@@ -280,6 +280,12 @@ getModifiers()
 	return mods;
 }
 
+static double
+translateMessageTime()
+{
+  return GetMessageTime() / 1000.; /* translate ms to seconds */
+}
+
 static void
 initMouseEvent(PuglEvent* event,
                PuglView*  view,
@@ -296,7 +302,7 @@ initMouseEvent(PuglEvent* event,
 		ReleaseCapture();
 	}
 
-	event->button.time   = GetMessageTime();
+	event->button.time   = translateMessageTime();
 	event->button.type   = press ? PUGL_BUTTON_PRESS : PUGL_BUTTON_RELEASE;
 	event->button.x      = GET_X_LPARAM(lParam);
 	event->button.y      = GET_Y_LPARAM(lParam);
@@ -312,7 +318,7 @@ initScrollEvent(PuglEvent* event, PuglView* view, LPARAM lParam, WPARAM wParam)
 	POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
 	ScreenToClient(view->impl->hwnd, &pt);
 
-	event->scroll.time   = GetMessageTime();
+	event->scroll.time   = translateMessageTime();
 	event->scroll.type   = PUGL_SCROLL;
 	event->scroll.x      = pt.x;
 	event->scroll.y      = pt.y;
@@ -357,7 +363,7 @@ initKeyEvent(PuglEvent* event, PuglView* view, bool press, LPARAM lParam)
 	ScreenToClient(view->impl->hwnd, &rpos);
 
 	event->key.type      = press ? PUGL_KEY_PRESS : PUGL_KEY_RELEASE;
-	event->key.time      = GetMessageTime();
+	event->key.time      = translateMessageTime();
 	event->key.state     = getModifiers();
 	event->key.x_root    = rpos.x;
 	event->key.y_root    = rpos.y;
@@ -499,7 +505,7 @@ handleMessage(PuglView* view, UINT message, WPARAM wParam, LPARAM lParam)
 		ClientToScreen(view->impl->hwnd, &pt);
 
 		event.motion.type    = PUGL_MOTION_NOTIFY;
-		event.motion.time    = GetMessageTime();
+		event.motion.time    = translateMessageTime();
 		event.motion.x       = GET_X_LPARAM(lParam);
 		event.motion.y       = GET_Y_LPARAM(lParam);
 		event.motion.x_root  = pt.x;

--- a/pugl/pugl_win.cpp
+++ b/pugl/pugl_win.cpp
@@ -137,7 +137,7 @@ puglCreateWindow(PuglView* view, const char* title)
 		return NULL;
 	}
 
-	int winFlags = WS_POPUPWINDOW | WS_CAPTION;
+	int winFlags = view->parent ? WS_CHILD : WS_POPUPWINDOW | WS_CAPTION;
 	if (view->hints.resizable) {
 		winFlags |= WS_SIZEBOX;
 		if (view->min_width || view->min_height) {

--- a/pugl/pugl_x11.c
+++ b/pugl/pugl_x11.c
@@ -297,6 +297,7 @@ translateEvent(PuglView* view, XEvent xevent)
 		event.any.flags |= PUGL_IS_SEND_EVENT;
 	}
 
+        const double time_ms_to_s = 1 / 1000.;
 	switch (xevent.type) {
 	case ClientMessage: {
 		char* type = XGetAtomName(view->impl->display,
@@ -323,7 +324,7 @@ translateEvent(PuglView* view, XEvent xevent)
 		break;
 	case MotionNotify:
 		event.type           = PUGL_MOTION_NOTIFY;
-		event.motion.time    = xevent.xmotion.time;
+		event.motion.time    = xevent.xmotion.time * time_ms_to_s;
 		event.motion.x       = xevent.xmotion.x;
 		event.motion.y       = xevent.xmotion.y;
 		event.motion.x_root  = xevent.xmotion.x_root;
@@ -334,7 +335,7 @@ translateEvent(PuglView* view, XEvent xevent)
 	case ButtonPress:
 		if (xevent.xbutton.button >= 4 && xevent.xbutton.button <= 7) {
 			event.type           = PUGL_SCROLL;
-			event.scroll.time    = xevent.xbutton.time;
+			event.scroll.time    = xevent.xbutton.time * time_ms_to_s;
 			event.scroll.x       = xevent.xbutton.x;
 			event.scroll.y       = xevent.xbutton.y;
 			event.scroll.x_root  = xevent.xbutton.x_root;
@@ -356,7 +357,7 @@ translateEvent(PuglView* view, XEvent xevent)
 			event.button.type   = ((xevent.type == ButtonPress)
 			                       ? PUGL_BUTTON_PRESS
 			                       : PUGL_BUTTON_RELEASE);
-			event.button.time   = xevent.xbutton.time;
+			event.button.time   = xevent.xbutton.time * time_ms_to_s;
 			event.button.x      = xevent.xbutton.x;
 			event.button.y      = xevent.xbutton.y;
 			event.button.x_root = xevent.xbutton.x_root;
@@ -370,7 +371,7 @@ translateEvent(PuglView* view, XEvent xevent)
 		event.type       = ((xevent.type == KeyPress)
 		                    ? PUGL_KEY_PRESS
 		                    : PUGL_KEY_RELEASE);
-		event.key.time   = xevent.xkey.time;
+		event.key.time   = xevent.xkey.time * time_ms_to_s;
 		event.key.x      = xevent.xkey.x;
 		event.key.y      = xevent.xkey.y;
 		event.key.x_root = xevent.xkey.x_root;
@@ -383,7 +384,7 @@ translateEvent(PuglView* view, XEvent xevent)
 		event.type            = ((xevent.type == EnterNotify)
 		                         ? PUGL_ENTER_NOTIFY
 		                         : PUGL_LEAVE_NOTIFY);
-		event.crossing.time   = xevent.xcrossing.time;
+		event.crossing.time   = xevent.xcrossing.time * time_ms_to_s;
 		event.crossing.x      = xevent.xcrossing.x;
 		event.crossing.y      = xevent.xcrossing.y;
 		event.crossing.x_root = xevent.xcrossing.x_root;

--- a/pugl/pugl_x11.c
+++ b/pugl/pugl_x11.c
@@ -222,6 +222,8 @@ keySymToSpecial(KeySym sym)
 	case XK_F10:       return PUGL_KEY_F10;
 	case XK_F11:       return PUGL_KEY_F11;
 	case XK_F12:       return PUGL_KEY_F12;
+        case XK_Delete:    return PUGL_KEY_DELETE;
+        case XK_BackSpace: return PUGL_KEY_BACKSPACE;
 	case XK_Left:      return PUGL_KEY_LEFT;
 	case XK_Up:        return PUGL_KEY_UP;
 	case XK_Right:     return PUGL_KEY_RIGHT;


### PR DESCRIPTION
SpectMorph is using pugl for its UI. Here are a few fixes that I've made that should be good enough for inclusion in upstream.

Event times: I use the event timestamp for double click detection (two clicks, less than 400ms apart). macOS uses a double timestamp for events in seconds, whereas the other platform use milliseconds as integers for the event time. To be able to use the same code for all platforms, I suggest always using double seconds as timestamps, this should be good enough to represent both.

Backspace/delete is not 0x8/0x7f on all platforms, so I suggest using the same strategy as for function keys: define PUGL_KEY_BACKSPACE | PUGL_KEY_DELETE, and map whatever platform specific code this has to these pugl keys.

On macOS current pugl has event->key.character and event->key.special set (i.e. if you use arrow keys), this is not consistent with the other platforms. So I've added a commit which enforces that a special key will always have character == 0.

The other fairly small fixes just fix bugs.

Ideally one day I would be able to use an unmodified version of pugl for SpectMorph, but there are a few more things to sort out. One main issue is that I need to resize the window if the user changes plugin zoom level, currently that is done using my own version of 
```
void puglSetResizeFunc(PuglView* view, PuglResizeFunc resizeFunc);
void puglPostResize(PuglView* view);
```
but here I currenly don't have a clean enough patch for upstream inclusion so I left this out at the moment.