### PR TITLE
Set UTF8 window title using NetWM hints

### DIFF
--- a/pugl/detail/x11.c
+++ b/pugl/detail/x11.c
@@ -132,6 +132,9 @@ puglCreateWindow(PuglView* view, const char* title)
 
 	if (title) {
 		XStoreName(display, win, title);
+		Atom netWmName = XInternAtom(display, "_NET_WM_NAME", False);
+		Atom utf8String = XInternAtom(display, "UTF8_STRING", False);
+		XChangeProperty(display, win, netWmName, utf8String, 8, PropModeReplace, (unsigned char *)title, strlen(title));
 	}
 
 	if (!view->parent) {


### PR DESCRIPTION
Hi, this permits to set any UTF character in window titles on X11 platform.
It's from recent edits of DPF's pugl fork.

PS. new pugl looks great, thanks for the effort