### PR TITLE
Mac: dispatch expose events from GL view drawRect

### DIFF
--- a/pugl/detail/mac.h
+++ b/pugl/detail/mac.h
@@ -36,6 +36,7 @@
 }
 
 - (void) dispatchConfigure:(NSRect)bounds;
+- (void) dispatchExpose:(NSRect)bounds;
 
 @end
 

--- a/pugl/detail/mac.m
+++ b/pugl/detail/mac.m
@@ -77,19 +77,24 @@
 	puglview->backend->resize(puglview, bounds.size.width, bounds.size.height);
 }
 
-- (void) drawRect:(NSRect)rect
+- (void) dispatchExpose:(NSRect)bounds
 {
-	const PuglEventExpose ev =  {
+	const PuglEventExpose ev = {
 		PUGL_EXPOSE,
 		0,
-		rect.origin.x,
-		rect.origin.y,
-		rect.size.width,
-		rect.size.height,
+		bounds.origin.x,
+		bounds.origin.y,
+		bounds.size.width,
+		bounds.size.height,
 		0
 	};
 
 	puglDispatchEvent(puglview, (const PuglEvent*)&ev);
+}
+
+- (void) drawRect:(NSRect)rect
+{
+	[self dispatchExpose:rect];
 }
 
 - (BOOL) isFlipped

--- a/pugl/detail/mac_gl.m
+++ b/pugl/detail/mac_gl.m
@@ -94,7 +94,7 @@ typedef NSUInteger NSWindowStyleMask;
 - (void) drawRect:(NSRect)rect
 {
 	PuglWrapperView* wrapper = (PuglWrapperView*)[self superview];
-	[wrapper dispatchExpose:[self bounds]];
+	[wrapper dispatchExpose:rect];
 }
 
 @end

--- a/pugl/detail/mac_gl.m
+++ b/pugl/detail/mac_gl.m
@@ -91,6 +91,12 @@ typedef NSUInteger NSWindowStyleMask;
 	[wrapper dispatchConfigure:[self bounds]];
 }
 
+- (void) drawRect:(NSRect)rect
+{
+	PuglWrapperView* wrapper = (PuglWrapperView*)[self superview];
+	[wrapper dispatchExpose:[self bounds]];
+}
+
 @end
 
 static int


### PR DESCRIPTION
Fixes broken expose events by calling dispatch from a suitable location - for #14

I noticed dispatching of configure events come from the `reshape` and `update` callbacks of the GL view.  By dispatching expose from `drawRect` subview works nicely, and also consistent with how configure events work. 

* Adds a dispatchExpose method to PuglWrapperView