### PR TITLE
x11_cairo: create double buffer with alpha content 

### DIFF
--- a/pugl/detail/x11_cairo.c
+++ b/pugl/detail/x11_cairo.c
@@ -62,7 +62,7 @@ puglX11CairoCreate(PuglView* view)
 	surface.back = cairo_xlib_surface_create(
 		impl->display, impl->win, impl->vi->visual, width, height);
 	surface.front = cairo_surface_create_similar(
-		surface.back, CAIRO_CONTENT_COLOR, width, height);
+		surface.back, CAIRO_CONTENT_COLOR_ALPHA, width, height);
 	surface.backCr  = cairo_create(surface.back);
 	surface.frontCr = cairo_create(surface.front);
 
@@ -140,7 +140,7 @@ puglX11CairoResize(PuglView* view, int width, int height)
 	cairo_destroy(surface->frontCr);
 	cairo_surface_destroy(surface->front);
 	if (!(surface->front = cairo_surface_create_similar(
-		      surface->back, CAIRO_CONTENT_COLOR, width, height))) {
+		      surface->back, CAIRO_CONTENT_COLOR_ALPHA, width, height))) {
 		return PUGL_CREATE_CONTEXT_FAILED;
 	}
 


### PR DESCRIPTION
Create X11 cairo double buffer with CAIRO_CONTENT_COLOR_ALPHA to prevent redraw flickering while resizing windows.

Redraw flickering could occur because in `x11.c` in function `puglDispatchEvents` the redraw events are merged and delayed until  `expose.count == 0`. In `x11_cairo.c` in function `puglX11CairoResize` the backing buffer is recreated.

Now imagine the following steps: configure event for resizing comes within a series of expose events but the last expose event is not received (i.e. expouse.count is still > 0). Then we have without alpha color a recreated backing buffer filled with black color. If now the application uses `puglEnterContext`, draws some content part and then `puglLeaveContext` the drawn content part is in the backing buffer and this backing buffer is drawn on the screen. But if it is only partly drawn by the application the undrawn part is black and causes flickering. If we have alpha color in the backing buffer the undrawn part in the buffer is transparent and therefore does not change the screen content.

The above description is not an imaginary scenario, I had the described effect in a real example application.

BTW: what do you think about making the merge of exposure events configurable? The expose count is already available at the pugl api (but currently the application will not get a value != 0 because of pugl event merging). A sophisticated application could handle merging of redraw events smarter than the pugl api could. If you want, I could try preparing a pull request for optionally disabling exposure event merging. 