### PR TITLE
new function puglPostRedisplayRect

### DIFF
--- a/pugl/detail/mac.m
+++ b/pugl/detail/mac.m
@@ -946,6 +946,14 @@ puglPostRedisplay(PuglView* view)
 	return PUGL_SUCCESS;
 }
 
+PuglStatus
+puglPostRedisplayRect(PuglView* view, PuglRect rect)
+{
+	[view->impl->drawView setNeedsDisplayInRect: 
+		CGRectMake(rect.x, rect.y, rect.width, rect.height)];
+	return PUGL_SUCCESS;
+}
+
 PuglNativeWindow
 puglGetNativeWindow(PuglView* view)
 {

--- a/pugl/detail/mac.m
+++ b/pugl/detail/mac.m
@@ -729,6 +729,7 @@ puglCreateWindow(PuglView* view, const char* title)
 		     puglConstraint(impl->wrapperView, NSLayoutAttributeWidth, view->minWidth)];
 	[impl->wrapperView addConstraint:
 		     puglConstraint(impl->wrapperView, NSLayoutAttributeHeight, view->minHeight)];
+	[impl->wrapperView setReshaped];
 
 	// Create draw view to be rendered to
 	int st = 0;
@@ -881,10 +882,12 @@ puglPollEvents(PuglWorld* world, const double timeout)
 	                     untilDate:date
 	                     inMode:NSDefaultRunLoopMode
 	                     dequeue:YES];
-
-	[world->impl->app postEvent:event atStart:true];
-
-	return PUGL_SUCCESS;
+	if (event) {
+		[world->impl->app postEvent:event atStart:true];
+		return PUGL_SUCCESS;
+	} else {
+		return PUGL_FAILURE;
+	}
 }
 
 PuglStatus

--- a/pugl/detail/mac_cairo.m
+++ b/pugl/detail/mac_cairo.m
@@ -59,6 +59,11 @@
 	[wrapper dispatchExpose:rect];
 }
 
+- (BOOL) isFlipped
+{
+	return YES;
+}
+
 @end
 
 static PuglStatus

--- a/pugl/detail/win.c
+++ b/pugl/detail/win.c
@@ -25,6 +25,7 @@
 #include <windows.h>
 #include <windowsx.h>
 
+#include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -786,6 +787,20 @@ puglPostRedisplay(PuglView* view)
 {
 	InvalidateRect(view->impl->hwnd, NULL, false);
 	view->redisplay = true;
+	return PUGL_SUCCESS;
+}
+
+PuglStatus
+puglPostRedisplayRect(PuglView* view, PuglRect rect)
+{
+	if (!view->redisplay) {
+		RECT r;
+		r.left   = (long) floor(rect.x);
+		r.top    = (long) floor(rect.y);
+		r.right  = (long) ceil (rect.x + rect.width);
+		r.bottom = (long) ceil (rect.y + rect.height);
+		InvalidateRect(view->impl->hwnd, &r, false);
+	}
 	return PUGL_SUCCESS;
 }
 

--- a/pugl/detail/x11.c
+++ b/pugl/detail/x11.c
@@ -106,31 +106,6 @@ puglInitViewInternals(void)
 	return (PuglInternals*)calloc(1, sizeof(PuglInternals));
 }
 
-PuglStatus
-puglPollEvents(PuglWorld* world, const double timeout)
-{
-	XFlush(world->impl->display);
-
-	const int fd   = ConnectionNumber(world->impl->display);
-	const int nfds = fd + 1;
-	int       ret  = 0;
-	fd_set    fds;
-	FD_ZERO(&fds);
-	FD_SET(fd, &fds);
-
-	if (timeout < 0.0) {
-		ret = select(nfds, &fds, NULL, NULL, NULL);
-	} else {
-		const long     sec  = (long)timeout;
-		const long     msec = (long)((timeout - (double)sec) * 1e6);
-		struct timeval tv   = {sec, msec};
-		ret = select(nfds, &fds, NULL, NULL, &tv);
-	}
-
-	return ret < 0 ? PUGL_UNKNOWN_ERROR
-	               : ret == 0 ? PUGL_FAILURE : PUGL_SUCCESS;
-}
-
 static PuglView*
 puglFindView(PuglWorld* world, const Window window)
 {
@@ -602,6 +577,31 @@ sendRedisplayEvent(PuglView* view)
 	                    0 };
 
 	XSendEvent(view->impl->display, view->impl->win, False, 0, (XEvent*)&ev);
+}
+
+PuglStatus
+puglPollEvents(PuglWorld* world, const double timeout)
+{
+	XFlush(world->impl->display);
+
+	const int fd   = ConnectionNumber(world->impl->display);
+	const int nfds = fd + 1;
+	int       ret  = 0;
+	fd_set    fds;
+	FD_ZERO(&fds);
+	FD_SET(fd, &fds);
+
+	if (timeout < 0.0) {
+		ret = select(nfds, &fds, NULL, NULL, NULL);
+	} else {
+		const long     sec  = (long)timeout;
+		const long     msec = (long)((timeout - (double)sec) * 1e6);
+		struct timeval tv   = {sec, msec};
+		ret = select(nfds, &fds, NULL, NULL, &tv);
+	}
+
+	return ret < 0 ? PUGL_UNKNOWN_ERROR
+	               : ret == 0 ? PUGL_FAILURE : PUGL_SUCCESS;
 }
 
 PUGL_API PuglStatus

--- a/pugl/detail/x11.c
+++ b/pugl/detail/x11.c
@@ -37,6 +37,7 @@
 #include <sys/time.h>
 
 #include <limits.h>
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -771,6 +772,22 @@ PuglStatus
 puglPostRedisplay(PuglView* view)
 {
 	view->redisplay = true;
+	return PUGL_SUCCESS;
+}
+
+PuglStatus
+puglPostRedisplayRect(PuglView* view, PuglRect rect)
+{
+	if (!view->redisplay) {
+		int x = (int)floor(rect.x);
+		int y = (int)floor(rect.y);
+		int w = (int) ceil(rect.x + rect.width)  - x;
+		int h = (int) ceil(rect.y + rect.height) - y;
+		XExposeEvent ev = { Expose, 0, True, view->impl->display, view->impl->win,
+		                    x, y, w, h, 0 };
+	
+		XSendEvent(view->impl->display, view->impl->win, False, 0, (XEvent*)&ev);
+	}
 	return PUGL_SUCCESS;
 }
 

--- a/pugl/detail/x11_cairo.c
+++ b/pugl/detail/x11_cairo.c
@@ -62,7 +62,7 @@ puglX11CairoCreate(PuglView* view)
 	surface.back = cairo_xlib_surface_create(
 		impl->display, impl->win, impl->vi->visual, width, height);
 	surface.front = cairo_surface_create_similar(
-		surface.back, CAIRO_CONTENT_COLOR, width, height);
+		surface.back, CAIRO_CONTENT_COLOR_ALPHA, width, height);
 	surface.backCr  = cairo_create(surface.back);
 	surface.frontCr = cairo_create(surface.front);
 
@@ -140,7 +140,7 @@ puglX11CairoResize(PuglView* view, int width, int height)
 	cairo_destroy(surface->frontCr);
 	cairo_surface_destroy(surface->front);
 	if (!(surface->front = cairo_surface_create_similar(
-		      surface->back, CAIRO_CONTENT_COLOR, width, height))) {
+		      surface->back, CAIRO_CONTENT_COLOR_ALPHA, width, height))) {
 		return PUGL_CREATE_CONTEXT_FAILED;
 	}
 

--- a/pugl/pugl.h
+++ b/pugl/pugl.h
@@ -552,10 +552,18 @@ PUGL_API bool
 puglGetVisible(PuglView* view);
 
 /**
-   Request a redisplay on the next call to puglDispatchEvents().
+   Request a redisplay for the whole view on the next call 
+   to puglDispatchEvents().
 */
 PUGL_API PuglStatus
 puglPostRedisplay(PuglView* view);
+
+/**
+   Request a redisplay of the view part specified by the 
+   coordinates in the given rectangle.
+*/
+PUGL_API PuglStatus
+puglPostRedisplayRect(PuglView* view, PuglRect rect);
 
 /**
    @}


### PR DESCRIPTION
As discussed in #19 here comes a pull request for requesting redisplaying a rectangular part of a PuglView using the new function:

```
PUGL_API PuglStatus
puglPostRedisplayRect(PuglView* view, PuglRect rect);
```

I tested this functionality thoroughly under X11 (local and remote display), Win and Mac. For Mac some minor fixes were necessary.

Edit: I tested only Cairo not OpenGL.