### PR TITLE
X11 event handling fixes

### DIFF
--- a/pugl/detail/x11.c
+++ b/pugl/detail/x11.c
@@ -106,31 +106,6 @@ puglInitViewInternals(void)
 	return (PuglInternals*)calloc(1, sizeof(PuglInternals));
 }
 
-PuglStatus
-puglPollEvents(PuglWorld* world, const double timeout)
-{
-	XFlush(world->impl->display);
-
-	const int fd   = ConnectionNumber(world->impl->display);
-	const int nfds = fd + 1;
-	int       ret  = 0;
-	fd_set    fds;
-	FD_ZERO(&fds);
-	FD_SET(fd, &fds);
-
-	if (timeout < 0.0) {
-		ret = select(nfds, &fds, NULL, NULL, NULL);
-	} else {
-		const long     sec  = (long)timeout;
-		const long     msec = (long)((timeout - (double)sec) * 1e6);
-		struct timeval tv   = {sec, msec};
-		ret = select(nfds, &fds, NULL, NULL, &tv);
-	}
-
-	return ret < 0 ? PUGL_UNKNOWN_ERROR
-	               : ret == 0 ? PUGL_FAILURE : PUGL_SUCCESS;
-}
-
 static PuglView*
 puglFindView(PuglWorld* world, const Window window)
 {
@@ -602,6 +577,31 @@ sendRedisplayEvent(PuglView* view)
 	                    0 };
 
 	XSendEvent(view->impl->display, view->impl->win, False, 0, (XEvent*)&ev);
+}
+
+PuglStatus
+puglPollEvents(PuglWorld* world, const double timeout)
+{
+	XFlush(world->impl->display);
+
+	const int fd   = ConnectionNumber(world->impl->display);
+	const int nfds = fd + 1;
+	int       ret  = 0;
+	fd_set    fds;
+	FD_ZERO(&fds);
+	FD_SET(fd, &fds);
+
+	if (timeout < 0.0) {
+		ret = select(nfds, &fds, NULL, NULL, NULL);
+	} else {
+		const long     sec  = (long)timeout;
+		const long     msec = (long)((timeout - (double)sec) * 1e6);
+		struct timeval tv   = {sec, msec};
+		ret = select(nfds, &fds, NULL, NULL, &tv);
+	}
+
+	return ret < 0 ? PUGL_UNKNOWN_ERROR
+	               : ret == 0 ? PUGL_FAILURE : PUGL_SUCCESS;
 }
 
 PUGL_API PuglStatus

--- a/pugl/detail/x11.c
+++ b/pugl/detail/x11.c
@@ -597,6 +597,9 @@ puglPollEvents(PuglWorld* world, const double timeout)
 	sendAllRedisplayEvents(world);
 	XFlush(world->impl->display);
 
+	if (XEventsQueued(world->impl->display, QueuedAlready)) {
+		return PUGL_SUCCESS;
+	}
 	const int fd   = ConnectionNumber(world->impl->display);
 	const int nfds = fd + 1;
 	int       ret  = 0;


### PR DESCRIPTION
Here are two fixes for X11 event handling.

1. pending redisplay requests are also send in `puglPollEvents`

2. `puglPollEvents` returns if there are events already read from the fd in the queue and does not wait until more events could be read from fd.
