### PR TITLE
X11: Fix XMoveResizeWindow error check

### DIFF
--- a/pugl/detail/x11.c
+++ b/pugl/detail/x11.c
@@ -872,7 +872,7 @@ puglSetFrame(PuglView* view, const PuglRect frame)
 	view->frame = frame;
 
 	if (view->impl->win &&
-	    XMoveResizeWindow(view->world->impl->display, view->impl->win,
+	    !XMoveResizeWindow(view->world->impl->display, view->impl->win,
 	                      (int)frame.x, (int)frame.y,
 	                      (int)frame.width, (int)frame.height)) {
 		return PUGL_UNKNOWN_ERROR;


### PR DESCRIPTION
I'm in the process of writing Rust bindings to Pugl, and just discovered that `puglSetFrame` returns `PUGL_UNKNOWN_ERROR` on X11 when the resize succeeds (if a window has actually been created). This is because the check against `XMoveResizeWindow` [assumes that it will return `0` on success](https://github.com/drobilla/pugl/blob/4fbcb7d243335346cfb1cc3b16addd9078193339/pugl/detail/x11.c#L875). However, [Xlib uses `0` to indicate an error](https://www.x.org/releases/current/doc/libX11/libX11/libX11.html#Errors), and as such [`XMoveResizeWindow` returns `1` on success](https://gitlab.freedesktop.org/xorg/lib/libx11/blob/master/src/ConfWind.c#L57). This very simple pull request flips the check against `XMoveResizeWindow` so that `0` will be treated as an error instead of `1`.

I couldn't find any other instances of checking the return values of Xlib functions in this manner in Pugl, so this seems to be the only place where a change like this is needed.